### PR TITLE
Fix hard delete when invoice is soft-deleted

### DIFF
--- a/Business/Services/InvoiceService.cs
+++ b/Business/Services/InvoiceService.cs
@@ -241,7 +241,7 @@ namespace Business.Services
         }
         public async Task<InvoiceResult> DeleteInvoiceAsync(string id)
         {
-            var invoice = await _invoiceRepo.GetAsync(i => i.InvoiceId == id);
+            var invoice = await _invoiceRepo.GetIncludingDeletedAsync(i => i.InvoiceId == id);
             if (invoice == null)
             {
                 return new InvoiceResult

--- a/Data/Repos/InvoiceRepo.cs
+++ b/Data/Repos/InvoiceRepo.cs
@@ -87,6 +87,7 @@ namespace Data.Repos
         public async Task HardDeleteAsync(string invoiceId)
         {
             var invoice = await _context.Invoices
+                .IgnoreQueryFilters()
                 .FirstOrDefaultAsync(i => i.InvoiceId == invoiceId);
 
             if (invoice is not null)


### PR DESCRIPTION
## Summary
- make HardDeleteAsync ignore EF Core query filters
- ensure DeleteInvoiceAsync can remove soft-deleted invoices

## Testing
- `dotnet build VivVentixeBackend.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68459ede294483299ca476483b1cb431